### PR TITLE
set GXY version to follow the release

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -10,7 +10,7 @@ galaxy_root: /srv/galaxy
 galaxy_user: {name: "{{ galaxy_user_name }}", shell: /bin/bash}
 # galaxy_commit_id: 1ad49865fbeb03551cf7774dc0c12e5cd27ff797 # release_23.0
 # galaxy_commit_id: 72070dbd0a6d0f418d0b8f914825ea2b8e6a0a88
-galaxy_commit_id: v24.1.3
+galaxy_commit_id: release_24.1
 galaxy_force_checkout: true
 miniconda_prefix: "{{ galaxy_tool_dependency_dir }}/_conda"
 miniconda_version: 24.4.0 # 23.5.2 # 23.5.0 # 4.12.0


### PR DESCRIPTION
I don't think we want to juggle minor versions, those are designed to not break things -- let's just follow the main release branch.