### PR TITLE
move galaxy_config_files to host vars

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -143,7 +143,7 @@ galaxy_config:
     galaxy_infrastructure_url: "https://{{ inventory_hostname }}"
     tus_upload_store: "{{ galaxy_tus_upload_store }}"
     # CVMFS
-    tool_data_table_config_path: 
+    tool_data_table_config_path:
     - /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml
     - /cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
     # Tool Dependencies
@@ -154,7 +154,7 @@ galaxy_config:
     -   auto_install: true
         type: mulled_singularity
     -   auto_install: false
-        type: build_mulled_singularity   
+        type: build_mulled_singularity
 #        cache_directory: /cvmfs/singularity.galaxyproject.org/all/
         cache_directory: "{{ galaxy_mutable_data_dir }}/singularity/mulled"
     # Data Library Directories
@@ -227,20 +227,6 @@ galaxy_config_files_public:
     dest: "{{ galaxy_server_dir }}/static/gcc2024-banner-3.png"
   - src: files/galaxy/static/style/additional_styles.css
     dest: "{{ galaxy_server_dir }}/static/style/additional_styles.css"
-
-galaxy_config_files:
-  - src: files/galaxy/themes.yml
-    dest: "{{ galaxy_config.galaxy.themes_config_file }}"
-  - src: "files/{{ inventory_hostname }}/tpv_rules_local.yml"
-    dest: "{{ tpv_mutable_dir }}/tpv_rules_{{ inventory_hostname }}.yml"
-  - src: files/{{ inventory_hostname }}/file_sources_conf.yml
-    dest: "{{ galaxy_config_dir }}/file_sources_conf.yml"
-  - src: files/{{ inventory_hostname }}/user_preferences_extra_conf.yml
-    dest: "{{ galaxy_config_dir }}/user_preferences_extra_conf.yml"
-  - src: "{{ lookup('first_found', ['templates/'+inventory_hostname+'/config/tool_conf.xml.j2', 'files/galaxy/config/tool_conf.xml']) }}"
-    dest: "{{ galaxy_config.galaxy.tool_config_file[0] }}"
-  - src: files/galaxy/config/oidc_config.xml
-    dest: "{{ galaxy_config_dir }}/oidc_config.xml"
 
 galaxy_config_templates:
   - src: templates/galaxy/config/job_resource_params_conf.xml.j2

--- a/host_vars/galaxy-qa1.galaxy.cloud.e-infra.cz/vars.yml
+++ b/host_vars/galaxy-qa1.galaxy.cloud.e-infra.cz/vars.yml
@@ -12,6 +12,20 @@ pulsar:
 
 pulsar_data_dir: "/storage/{{ pulsar.nfs_home }}/home/{{ pulsar.user_name }}/{{ pulsar.nfs_prefix }}"
 
+galaxy_config_files:
+  - src: files/galaxy/themes.yml
+    dest: "{{ galaxy_config.galaxy.themes_config_file }}"
+  - src: "files/{{ inventory_hostname }}/tpv_rules_local.yml"
+    dest: "{{ tpv_mutable_dir }}/tpv_rules_{{ inventory_hostname }}.yml"
+  - src: files/{{ inventory_hostname }}/file_sources_conf.yml
+    dest: "{{ galaxy_config_dir }}/file_sources_conf.yml"
+  - src: files/{{ inventory_hostname }}/user_preferences_extra_conf.yml
+    dest: "{{ galaxy_config_dir }}/user_preferences_extra_conf.yml"
+  - src: "{{ lookup('first_found', ['templates/'+inventory_hostname+'/config/tool_conf.xml.j2', 'files/galaxy/config/tool_conf.xml']) }}"
+    dest: "{{ galaxy_config.galaxy.tool_config_file[0] }}"
+  - src: files/galaxy/config/oidc_config.xml
+    dest: "{{ galaxy_config_dir }}/oidc_config.xml"
+
 # copy_tools_from: usegalaxy.eu
 
 # just test

--- a/host_vars/galaxy-qa2.galaxy.cloud.e-infra.cz/vars.yml
+++ b/host_vars/galaxy-qa2.galaxy.cloud.e-infra.cz/vars.yml
@@ -1,4 +1,4 @@
-# galaxy_build_client: false
+galaxy_build_client: false
 galaxy_commit_id: release_24.2
 
 csnt_brand: QA2-TEST
@@ -12,3 +12,17 @@ pulsar:
   pbs_queue: galaxyqa
   pbs_gpu_queue: galaxy_gpu
 pulsar_data_dir: "/storage/{{ pulsar.nfs_home }}/home/{{ pulsar.user_name }}/{{ pulsar.nfs_prefix }}"
+
+galaxy_config_files:
+  - src: files/galaxy/themes.yml
+    dest: "{{ galaxy_config.galaxy.themes_config_file }}"
+  - src: "files/{{ inventory_hostname }}/tpv_rules_local.yml"
+    dest: "{{ tpv_mutable_dir }}/tpv_rules_{{ inventory_hostname }}.yml"
+  - src: files/{{ inventory_hostname }}/file_sources_conf.yml
+    dest: "{{ galaxy_config_dir }}/file_sources_conf.yml"
+  - src: files/{{ inventory_hostname }}/user_preferences_extra_conf.yml
+    dest: "{{ galaxy_config_dir }}/user_preferences_extra_conf.yml"
+  - src: "{{ lookup('first_found', ['templates/'+inventory_hostname+'/config/tool_conf.xml.j2', 'files/galaxy/config/tool_conf.xml']) }}"
+    dest: "{{ galaxy_config.galaxy.tool_config_file[0] }}"
+  - src: files/galaxy/config/oidc_config.xml
+    dest: "{{ galaxy_config_dir }}/oidc_config.xml"

--- a/host_vars/usegalaxy.cz/vars.yml
+++ b/host_vars/usegalaxy.cz/vars.yml
@@ -18,6 +18,16 @@ pulsar:
   pbs_queue: galaxycz
   pbs_gpu_queue: galaxy_gpu
 
+galaxy_config_files:
+  - src: files/galaxy/themes.yml
+    dest: "{{ galaxy_config.galaxy.themes_config_file }}"
+  - src: "files/{{ inventory_hostname }}/tpv_rules_local.yml"
+    dest: "{{ tpv_mutable_dir }}/tpv_rules_{{ inventory_hostname }}.yml"
+  - src: "{{ lookup('first_found', ['templates/'+inventory_hostname+'/config/tool_conf.xml.j2', 'files/galaxy/config/tool_conf.xml']) }}"
+    dest: "{{ galaxy_config.galaxy.tool_config_file[0] }}"
+  - src: files/galaxy/config/oidc_config.xml
+    dest: "{{ galaxy_config_dir }}/oidc_config.xml"
+
 pulsar_data_dir: "/storage/{{ pulsar.nfs_home }}/home/{{ pulsar.user_name }}/{{ pulsar.nfs_prefix }}"
 
 copy_tools_from: usegalaxy.eu


### PR DESCRIPTION
different instances will need different configs so we should define that per-host

there is a syntax for expanding list of hashes within jinja template and vars file but it is very clumsy and we decided to not take that path

closes #56 