### PR TITLE
OIDC scope backtrack 

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -87,7 +87,7 @@ galaxy_config:
     object_store_config_file: "{{ galaxy_config_dir }}/object_store_conf.xml"
     enable_oidc: "{{ csnt_enable_oidc }}"
     oidc_config_file: "{{ csnt_oidc_config_file }}"
-    enable_oidc_backends_config_file: "{{ csnt_oidc_backends_config_file }}"
+    oidc_backends_config_file: "{{ csnt_oidc_backends_config_file }}"
     logo_src: "https://www.e-infra.cz/img/logo.svg"
     themes_config_file: "{{ galaxy_config_dir }}/themes.yml"
     admin_users: "{{ vault_admin_users }}"

--- a/templates/galaxy/config/oidc_backends_config.xml.j2
+++ b/templates/galaxy/config/oidc_backends_config.xml.j2
@@ -6,6 +6,6 @@
       <redirect_uri>https://{{ inventory_hostname }}/authnz/keycloak/callback</redirect_uri>
       <url>https://login.e-infra.cz/oidc</url>
       <icon>https://www.e-infra.cz/img/logo.svg</icon>
-      <extra_scopes>offline_access</extra_scopes>
+      <!-- <extra_scopes>offline_access</extra_scopes> -->
     </provider>
 </OIDC>


### PR DESCRIPTION
with https://github.com/galaxyproject/galaxy/pull/19471 in 24.2 we can stop trying to juggle the refresh tokens and just ignore them