### PR TITLE
raises walltime of abims_xcms_fillPeaks

### DIFF
--- a/templates/galaxy/config/tpv_rules_local.yml.j2
+++ b/templates/galaxy/config/tpv_rules_local.yml.j2
@@ -32,6 +32,10 @@ tools:
       reject:
       - pulsar
 
+  .*/abims_xcms_fillPeaks/.*:
+    context:
+      walltime: 48
+
   .*/tp_cut_tool/.*:
     mem: 1
 


### PR DESCRIPTION
from 24 to 48 hours