### PR TITLE
Increase abims_xcms_fillPeaks wall time in TPV config

### DIFF
--- a/templates/galaxy/config/tpv_rules_local.yml.j2
+++ b/templates/galaxy/config/tpv_rules_local.yml.j2
@@ -34,7 +34,7 @@ tools:
 
   .*/abims_xcms_fillPeaks/.*:
     context:
-      walltime: 48
+      walltime: 96
 
   .*/tp_cut_tool/.*:
     mem: 1


### PR DESCRIPTION
from 48 to 96 hours according to the suggestion in #102