### PR TITLE
deploy inveniordm on gcz, already tested on qa2

### DIFF
--- a/files/usegalaxy.cz/file_sources_conf.yml
+++ b/files/usegalaxy.cz/file_sources_conf.yml
@@ -1,0 +1,8 @@
+- type: inveniordm
+  id: invenio_sandbox
+  doc: This is the Sandbox instance of Invenio. It is used for testing purposes only, content is NOT preserved. DOIs created in this instance are not real and will not resolve.
+  label: Invenio RDM Sandbox Repository (TESTING)
+  url: https://inveniordm.web.cern.ch/
+  token: ${user.user_vault.read_secret('preferences/invenio_sandbox/token')}
+  public_name: ${user.preferences['invenio_sandbox|public_name']}
+  writable: true

--- a/files/usegalaxy.cz/user_preferences_extra_conf.yml
+++ b/files/usegalaxy.cz/user_preferences_extra_conf.yml
@@ -1,0 +1,17 @@
+preferences:
+    invenio_sandbox:
+        description: Your Invenio RDM _SANDBOX_ Account
+        inputs:
+            - name: token
+              label: Personal Token to publish records to Invenio RDM
+              type: secret
+              store: vault
+              required: False
+            - name: public_name
+              label: Public name to publish records (formatted as "Lastname, Firstname")
+              type: text
+              required: False
+            - name: public_records
+              label: Whether to make new draft records publicly accessible (Yes) or restricted (No).
+              type: boolean
+              required: False

--- a/host_vars/usegalaxy.cz/vars.yml
+++ b/host_vars/usegalaxy.cz/vars.yml
@@ -39,3 +39,7 @@ galaxy_config_files:
     dest: "{{ galaxy_config_dir }}/oidc_config.xml"
   - src: "files/{{ inventory_hostname }}/all_tools.yml"
     dest: "{{ galaxy_config_dir }}/plugins/activities/all_tools.yml"
+  - src: files/{{ inventory_hostname }}/file_sources_conf.yml
+    dest: "{{ galaxy_config_dir }}/file_sources_conf.yml"
+  - src: files/{{ inventory_hostname }}/user_preferences_extra_conf.yml
+    dest: "{{ galaxy_config_dir }}/user_preferences_extra_conf.yml"


### PR DESCRIPTION
galaxy secret vault is now deployed by default so is not added here