### PR TITLE
Rejects docker of three tools

### DIFF
--- a/files/galaxy-umsa.grid.cesnet.cz/tpv_rules_local.yml
+++ b/files/galaxy-umsa.grid.cesnet.cz/tpv_rules_local.yml
@@ -47,3 +47,21 @@ tools:
     cores: 1 
     context:
       walltime: 2
+
+  .*/qcxms_neutral_run/.*:
+    mem: 32
+    scheduling:
+      reject:
+      - docker
+
+  .*/qcxms_production_run/.*:
+    mem: 8
+    scheduling:
+      reject:
+      - docker
+
+  .*/recetox_msfinder/.*:
+    mem: 16
+    scheduling:
+      reject:
+      - docker


### PR DESCRIPTION
I wonder, if it could be easier and more general to specify `scheduling: reject: - docker` for the default tool in tpv_rules_meta.yml which all other tools inherit from. 