### PR TITLE
Update oidc_backends_config.xml.j2 Lifescience oidc update

### DIFF
--- a/templates/usegalaxy.cz/config/oidc_backends_config.xml.j2
+++ b/templates/usegalaxy.cz/config/oidc_backends_config.xml.j2
@@ -12,7 +12,7 @@
         <client_id>{{ elixir_client_id }}</client_id>
         <client_secret>{{ elixir_client_secret }}</client_secret>
         <redirect_uri>https://{{ inventory_hostname }}/authnz/elixir/callback</redirect_uri>
-        <url>https://login.e-infra.cz/oidc</url>
+        <url>https://login.aai.lifescience-ri.eu/oidc</url>
         <icon>https://lifescience-ri.eu/fileadmin/lifescience-ri/media/Images/login-grey-wide.jpg.png</icon>
         <!-- <extra_scopes>offline_access</extra_scopes> -->
     </provider>


### PR DESCRIPTION
Based on the [ELIXIR to LS AAI service migration](https://perunaai.atlassian.net/wiki/spaces/PERUN/pages/882245683/ELIXIR+to+LS+AAI+service+migration) the oidc config was changed to `https://login.aai.lifescience-ri.eu/oidc` instead of `https://login.elixir-czech.org/oidc/`