### PR TITLE
fixing TUSd hooks handling problem

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -56,7 +56,7 @@ galaxy_root: /srv/galaxy
 galaxy_mutable_config_dir: "{{ galaxy_root }}/var/config"
 galaxy_gravity_state_dir: "{{ galaxy_root }}/var/gravity"
 galaxy_tool_dependency_dir: "{{ galaxy_root }}/var/dependencies"
-galaxy_user: {name: "{{ galaxy_user_name }}", shell: /bin/bash}
+galaxy_user: {name: "{{ galaxy_user_name }}", group: "{{ galaxy_user_group_name }}", shell: /bin/bash}
 galaxy_commit_id: release_25.0
 galaxy_force_checkout: true
 galaxy_job_config_file: "{{ galaxy_config_dir }}/galaxy.yml"
@@ -441,6 +441,21 @@ rabbitmq_users:
 # TUS
 galaxy_tusd_port: 1080
 galaxy_tus_upload_store: "{{ galaxy_mutable_data_dir }}/tus" # /mnt/data/tus
+
+tusd_instances:
+      - name: uploads
+        # user that tusd will run as
+        user: "{{ galaxy_user.name }}"
+        # group that tusd will run as
+        group: "{{ galaxy_user.group }}"
+        # args passed to tusd
+        args:
+          - -host=localhost
+          - "-port={{ galaxy_tusd_port }}"
+          - "-upload-dir={{ galaxy_tus_upload_store }}"
+          - "-hooks-http=https://{{ inventory_hostname }}{{ csnt_galaxy_url_prefix }}/api/upload/hooks"
+          - -hooks-http-forward-headers=X-Api-Key,Cookie
+          - -hooks-enabled-events pre-create
 
 #Redis
 galaxy_additional_venv_packages:

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -90,12 +90,17 @@ server {
 		client_max_body_size        0;
 		proxy_pass http://localhost:{{ galaxy_tusd_port }}/files;
 	}
+{% block tus_hook %}
+    {% if csnt_galaxy_url_prefix != '' %}        
+        #DEMON: this piece of code shouldn't definitely be on instance without special galaxy_url_prefix!
         #DEMON: hopefully just a temporary hack, need to find out how to configure TUSd hook via ansible role
-	#DEMON: Not sure if we still need this
+        #DEMON: Not sure if we still need this
         location /api/upload/hooks {
                 rewrite ^/api/upload/hooks(.*)$ {{ csnt_galaxy_url_prefix }}/api/upload/hooks$1 break;
                 proxy_pass https://{{ inventory_hostname }};
         }
+    {% endif %}
+{% endblock tus_hook %}
 
 
 	# Static files can be more efficiently served by Nginx. Why send the


### PR DESCRIPTION
Hot-fix for TUSd hooks handling by Nginx. The trouble was in the definition of a special location for the tusd hooks handling in the nginx template for Galaxy. It came from branch for RE and it was needed for RE at some point (because of using galaxy_url_prefix). I don't quite understand why it made trouble, but this piece of code is no longer useful, as we now have the tusd hooks templated, including galaxy_url_prefix.