### PR TITLE
removes explicit tusd instance definition 

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -442,21 +442,6 @@ rabbitmq_users:
 galaxy_tusd_port: 1080
 galaxy_tus_upload_store: "{{ galaxy_mutable_data_dir }}/tus" # /mnt/data/tus
 
-tusd_instances:
-      - name: uploads
-        # user that tusd will run as
-        user: "{{ galaxy_user.name }}"
-        # group that tusd will run as
-        group: "{{ galaxy_user.group }}"
-        # args passed to tusd
-        args:
-          - -host=localhost
-          - "-port={{ galaxy_tusd_port }}"
-          - "-upload-dir={{ galaxy_tus_upload_store }}"
-          - "-hooks-http=https://{{ inventory_hostname }}{{ csnt_galaxy_url_prefix }}/api/upload/hooks"
-          - -hooks-http-forward-headers=X-Api-Key,Cookie
-          - -hooks-enabled-events pre-create
-
 #Redis
 galaxy_additional_venv_packages:
   - redis

--- a/host_vars/repeatexplorer-elixir.cerit-sc.cz/vars.yml
+++ b/host_vars/repeatexplorer-elixir.cerit-sc.cz/vars.yml
@@ -125,20 +125,20 @@ galaxy_extra_dirs:
   - "{{ galaxy_config_dir }}/plugins/activities"
   - "{{ galaxy_server_dir }}/static/images/umbr_programs_icons"
 
-tusd_instances:
-      - name: uploads
-        # user that tusd will run as
-        user: "{{ galaxy_user.name }}"
-        # group that tusd will run as
-        group: "{{ galaxy_user.group }}"
-        # args passed to tusd
-        args:
-          - -host=localhost
-          - "-port={{ galaxy_tusd_port }}"
-          - "-upload-dir={{ galaxy_tus_upload_store }}"
-          - "-hooks-http=https://{{ inventory_hostname }}{{ csnt_galaxy_url_prefix }}/api/upload/hooks"
-          - -hooks-http-forward-headers=X-Api-Key,Cookie
-          - -hooks-enabled-events pre-create
+#tusd_instances:
+#      - name: uploads
+#        # user that tusd will run as
+#        user: "{{ galaxy_user.name }}"
+#        # group that tusd will run as
+#        group: "{{ galaxy_user.group }}"
+#        # args passed to tusd
+#        args:
+#          - -host=localhost
+#          - "-port={{ galaxy_tusd_port }}"
+#          - "-upload-dir={{ galaxy_tus_upload_store }}"
+#          - "-hooks-http=https://{{ inventory_hostname }}{{ csnt_galaxy_url_prefix }}/api/upload/hooks"
+#          - -hooks-http-forward-headers=X-Api-Key,Cookie
+#          - -hooks-enabled-events pre-create
 
 flower_bind_interface: localhost
 flower_port: 5555


### PR DESCRIPTION
to prevent installing an extra systemd service. It turns out that the explicit `tusd_instances` is not needed. It only creates the extra `tusd-<name>.service`. I think if TUSd is enabled in Gravity, it must be somehow templated to create a service called `galaxy-tusd.service` under the supervision of Gravity. Which works perfectly.