### PR TITLE
add mulled singularity container resolver with the least priority

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -191,6 +191,7 @@ galaxy_config:
       - type: cached_mulled_singularity
         cache_directory: /cvmfs/singularity.galaxyproject.org/all/
         cache_directory_cacher_type: dir_mtime
+      - type: mulled_singularity
     # Data Library Directories
     library_import_dir: "{{ csnt_library_import_dir }}"
     user_library_import_dir: "{{ csnt_user_library_import_dir }}"


### PR DESCRIPTION
this is needed because galaxy's cvmfs is lagging behind mulled containers being pushed to quay; this just happened to us with [hisat2](https://github.com/BioContainers/multi-package-containers/pull/3852)