### PR TITLE
adds singularity volume for /tmp

### DIFF
--- a/templates/galaxy/config/tpv_rules_meta.yml.j2
+++ b/templates/galaxy/config/tpv_rules_meta.yml.j2
@@ -353,7 +353,9 @@ destinations:
     runner: pulsar_tpv_runner
     params:
       singularity_enabled: true
-      singularity_volumes: "$job_directory:rw,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/cvmfs/data.galaxyproject.org:ro,$SCRATCHDIR:rw"
+      # DEMON: We need to enable /tmp for writing and it could be possible either by using the tmp_dir: treu or by adding explicit volume like $SCRATCHDIR:/tmp:rw (which should be more benefitial for us)
+      #tmp_dir: true
+      singularity_volumes: "$job_directory:rw,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/cvmfs/data.galaxyproject.org:ro,$SCRATCHDIR:rw,$SCRATCHDIR:/tmp:rw"
       singularity_default_container_id: "/cvmfs/singularity.galaxyproject.org/all/python:3.8.3"
       singularity_run_extra_arguments: >-
         --env JAVA_OPTS="-Xmx{int(mem)}g -Djava.io.tmpdir=$SCRATCHDIR"


### PR DESCRIPTION
We just found out that `/tmp` was not writable in Singularity containers all the time because most tools probably use explicitly defined TMP, TEMP, or TMPDIR variables. Therefore, we added a new volume to be bound for `$SCRATCHDIR:/tmp` explicitly.