### PR TITLE
Add a new walltime context for funannotate rules

### DIFF
--- a/templates/galaxy/config/tpv_rules_meta.yml.j2
+++ b/templates/galaxy/config/tpv_rules_meta.yml.j2
@@ -62,6 +62,9 @@ tools:
         cores: int(job.get_param_values(app)['__job_resource']['cores'])
         context:
            walltime: "{int(job.get_param_values(app)['__job_resource']['time'])}"
+  toolshed.g2.bx.psu.edu/repos/iuc/funannotate.*:
+    context:
+      walltime: 96
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_import/anndata_import/.*:
     # DEMON: the following mem setting is taken from tpv-shared at 17-03-2026 - this should conserve it for us
     mem: 2 + input_size * 10


### PR DESCRIPTION
Add a new walltime context for funannotate rules. I started with 96h instead of the default 24h. It's in a trying session, let's wait to see if that is enough.