### PR TITLE
raises walltime and memory for mummer_nucmer tool in TPV

### DIFF
--- a/templates/galaxy/config/tpv_rules_meta.yml.j2
+++ b/templates/galaxy/config/tpv_rules_meta.yml.j2
@@ -62,6 +62,10 @@ tools:
         cores: int(job.get_param_values(app)['__job_resource']['cores'])
         context:
            walltime: "{int(job.get_param_values(app)['__job_resource']['time'])}"
+  toolshed.g2.bx.psu.edu/repos/iuc/mummer_nucmer/mummer_nucmer/.*:
+    mem: 32
+    context:
+      walltime: 96
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_import/anndata_import/.*:
     # DEMON: the following mem setting is taken from tpv-shared at 17-03-2026 - this should conserve it for us
     mem: 2 + input_size * 10


### PR DESCRIPTION
One job hit 24h walltime and used 25GB of RAM. This is a memento of what happened. A new testing job is running now to see if 96h walltime is enough.