### PR TITLE
Umsa 26.0

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -136,7 +136,7 @@ galaxy_config:
     cleanup_job: onsuccess
     smtp_server: "{{ csnt_smtp_server }}"
     error_email_to: "{{  csnt_contact_email  }}"
-    allow_user_creation: false
+    allow_user_creation: false # deprecated, eventually replace with allow_local_account_creation: false
     disable_local_accounts: true
     require_login: "{{ csnt_require_login }}"
     database_connection: "postgresql:///{{ galaxy_db_name }}?host=/var/run/postgresql"

--- a/host_vars/galaxy-umsa.grid.cesnet.cz/vars.yml
+++ b/host_vars/galaxy-umsa.grid.cesnet.cz/vars.yml
@@ -1,11 +1,17 @@
 # where to put most of the data; we use RBD or NBD volumes
 rbd_mount_point: /rbd
 rbd_data_dir: "{{ rbd_mount_point }}/galaxy-umsa_data"
+enable_tiaas: false
+shed_tools_shadowing: true
+
 galaxy_mutable_data_dir: "{{ rbd_data_dir }}"
-
-galaxy_commit_id: release_25.1
+galaxy_commit_id: release_26.0
 galaxy_build_client: false
+galaxy_client_make_target: client-production
+galaxy_user_name: galaxyumsa
+galaxy_user_group_name: galaxyumsa
 
+csnt_brand: UMSA
 csnt_log_level: DEBUG
 csnt_enable_notification_system: true
 csnt_short_term_storage_dir: "{{ galaxy_mutable_data_dir }}/short_term_web_storage"
@@ -17,11 +23,6 @@ csnt_tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
 csnt_edam_panel_views: operations,topics
 csnt_default_panel_view: all_tools
 csnt_allow_path_paste: true
-enable_tiaas: false
-shed_tools_shadowing: true
-
-galaxy_user_name: galaxyumsa
-galaxy_user_group_name: galaxyumsa
 
 pulsar:
   user_name: galaxyumsa

--- a/host_vars/usegalaxy.cz/vars.yml
+++ b/host_vars/usegalaxy.cz/vars.yml
@@ -1,12 +1,13 @@
 extra_certbot_domains:
  - "galaxy-cz.grid.cesnet.cz"
  - "galaxy.metacentrum.cz"
-
+enable_tiaas: true
+shed_tools_shadowing: true
 # where to put most of the data; we use RBD or NBD volumes
 rbd_mount_point: /rbd
 rbd_data_dir: "{{ rbd_mount_point }}/data"
-galaxy_mutable_data_dir: "{{ rbd_data_dir }}"
 
+galaxy_mutable_data_dir: "{{ rbd_data_dir }}"
 galaxy_commit_id: release_25.1
 galaxy_build_client: false
 
@@ -15,8 +16,6 @@ csnt_enable_notification_system: true
 csnt_short_term_storage_dir: "{{ galaxy_mutable_data_dir }}/short_term_web_storage"
 csnt_edam_panel_views: operations,topics
 csnt_default_panel_view: all_tools
-enable_tiaas: true
-shed_tools_shadowing: true
 
 pulsar:
   user_name: galaxyeu

--- a/templates/galaxy/config/file_source_templates.yml.j2
+++ b/templates/galaxy/config/file_source_templates.yml.j2
@@ -1,0 +1,1 @@
+- include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/onedata.yml"


### PR DESCRIPTION
onedata file source template is now enabled by default because galaxy does not like to have specific path to an existing config file which is empty