### PR TITLE
Increase compute capacity on UMSA for registered users

### DIFF
--- a/host_vars/galaxy-umsa.grid.cesnet.cz/vars.yml
+++ b/host_vars/galaxy-umsa.grid.cesnet.cz/vars.yml
@@ -15,7 +15,7 @@ csnt_brand: UMSA
 csnt_log_level: DEBUG
 csnt_enable_notification_system: true
 csnt_short_term_storage_dir: "{{ galaxy_mutable_data_dir }}/short_term_web_storage"
-csnt_registered_user_jobs_limit: 100
+csnt_registered_user_jobs_limit: 256
 csnt_tool_config_file:
 - "{{ galaxy_config_dir }}/tool_conf.xml"
 - "{{ galaxy_config_dir }}/local_tool_conf.xml"


### PR DESCRIPTION
Given our increased workloads and extended testing, it would be great if we could have more compute capacity available and more jobs running in parallel for registered users.

If possible, this could also just be enabled for the RCX user group ... not sure how it looks with overall compute capacity etc. :)

Thanks a lot!