### PR TITLE
fixes handling singularity cache for docker images

### DIFF
--- a/files/repeatexplorer-elixir.cerit-sc.cz/tpv_rules_local.yml
+++ b/files/repeatexplorer-elixir.cerit-sc.cz/tpv_rules_local.yml
@@ -173,7 +173,7 @@ tools:
     context:
       scratch: 64
       walltime: 168
-  
+
   # ReapeatExplorer tools http://toolshed.g2.bx.psu.edu/repos/petr-novak/repeatexplorer2_testing
   toolshed.g2.bx.psu.edu/repos/petr-novak/repeatexplorer2_testing/repeatexplorer2/.*:
     cores: 10
@@ -186,6 +186,7 @@ tools:
         - conda
       require:
         - singularity
+        - repex
     container_resolvers:
     -   type: cached_explicit_singularity
         cache_directory: "$SINGULARITY_CACHEDIR"

--- a/templates/galaxy/config/tpv_rules_meta.yml.j2
+++ b/templates/galaxy/config/tpv_rules_meta.yml.j2
@@ -374,7 +374,7 @@ destinations:
         --env JAVA_OPTS="-Xmx{int(mem)}g -Djava.io.tmpdir=$SCRATCHDIR"
         --env JAVA_TOOL_OPTIONS="-Xmx{int(mem)}g -Djava.io.tmpdir=$SCRATCHDIR"
     env:
-      SINGULARITY_CACHEDIR: "/cvmfs/singularity.galaxyproject.org/all/"
+      SINGULARITY_CACHEDIR: $SCRATCHDIR
       SINGULARITY_TMPDIR: $SCRATCHDIR
       XDG_CACHE_HOME: $SCRATCHDIR
     scheduling:
@@ -456,3 +456,14 @@ destinations:
     scheduling:
       require:
         - alphafold
+  tpv_pulsar_repex:
+    inherits: tpv_pulsar
+    env:
+      SINGULARITY_CACHEDIR: "/storage/brno11-elixir/home/galaxyelixir/pulsar-re/files/singularity_cache"
+    container_resolvers:
+    -   type: explicit_singularity
+    -   cache_directory: "$SINGULARITY_CACHEDIR"
+        type: cached_mulled_singularity
+    scheduling:
+      require:
+        - repex


### PR DESCRIPTION
We were discussing this. It is necessary to do it this way before handling all the not-shared-in-common-cvmfs containers on our CVMFS. It was already deployed, but apparently wasn't added to the playbook, as I just found out.