### PR TITLE
Raises walltime in TPV config for Canu and Hifiasm

### DIFF
--- a/templates/galaxy/config/tpv_rules_meta.yml.j2
+++ b/templates/galaxy/config/tpv_rules_meta.yml.j2
@@ -62,6 +62,12 @@ tools:
         cores: int(job.get_param_values(app)['__job_resource']['cores'])
         context:
            walltime: "{int(job.get_param_values(app)['__job_resource']['time'])}"
+  toolshed.g2.bx.psu.edu/repos/bgruening/canu/canu/.*:
+    context:
+      walltime: 96
+  toolshed.g2.bx.psu.edu/repos/bgruening/hifiasm/hifiasm/.*:
+    context:
+      walltime: 96
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_import/anndata_import/.*:
     # DEMON: the following mem setting is taken from tpv-shared at 17-03-2026 - this should conserve it for us
     mem: 2 + input_size * 10


### PR DESCRIPTION
I increased their walltime to 96h after each one's job hit 24h walltime ([rt ticket](https://rt.cesnet.cz/rt/Ticket/Display.html?id=1533802))