### PR TITLE
LLM stable aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ roles/*
 
 # this is ours
 !roles/usegalaxy_cz.llm_hub
-genai_models.loc

--- a/files/galaxy/genai_models.loc
+++ b/files/galaxy/genai_models.loc
@@ -1,8 +1,8 @@
 #<model_id>	<display_name>	<domain>	<provider>	<free_tag>
-glm 	Latest GLM, large context	text	CERIT-SC	tag
-kimi	Latest Kimi, strong coding performance	multimodal	CERIT-SC	tag
-deepseek	Latest DeepSeek, mathematics, coding	text	CERIT-SC	tag
-deepseek-thinking	Latest DeepSeek, reasoning on	text	CERIT-SC	tag
-mini	Compact fast default model	text	CERIT-SC	tag
-coder	Default model suitable for coding	multimodal	CERIT-SC	tag
-thinker	Default model suitable for complex reasoning	text	CERIT-SC	tag
+glm 	glm 	glm: Latest GLM, large context	text	CERIT-SC	tag
+kimi	kimi	kimi: Latest Kimi, strong coding performance	multimodal	CERIT-SC	tag
+deepseek	deepseek	deepseek: Latest DeepSeek, mathematics, coding	text	CERIT-SC	tag
+deepseek-thinking	deepseek-thinking	deepseek-thinking: Latest DeepSeek, reasoning on	text	CERIT-SC	tag
+mini	mini	mini: Compact fast default model	text	CERIT-SC	tag
+coder	coder	coder: Default multimodal model suitable also for coding	multimodal	CERIT-SC	tag
+thinker	thinker	thinker: Default model suitable for complex reasoning	text	CERIT-SC	tag

--- a/files/galaxy/genai_models.loc
+++ b/files/galaxy/genai_models.loc
@@ -1,0 +1,8 @@
+#<model_id>	<display_name>	<domain>	<provider>	<free_tag>
+glm 	Latest GLM, large context	text	CERIT-SC	tag
+kimi	Latest Kimi, strong coding performance	multimodal	CERIT-SC	tag
+deepseek	Latest DeepSeek, mathematics, coding	text	CERIT-SC	tag
+deepseek-thinking	Latest DeepSeek, reasoning on	text	CERIT-SC	tag
+mini	Compact fast default model	text	CERIT-SC	tag
+coder	Default model suitable for coding	multimodal	CERIT-SC	tag
+thinker	Default model suitable for complex reasoning	text	CERIT-SC	tag

--- a/roles/usegalaxy_cz.llm_hub/tasks/main.yml
+++ b/roles/usegalaxy_cz.llm_hub/tasks/main.yml
@@ -1,18 +1,8 @@
 ---
 
-- name: Retrieve current list of LLMs
-  delegate_to: localhost
-  shell: |
-    echo '#<value>	<model_id>	<display_name>	<domain>	<provider>	<free_tag>' > "files/{{ inventory_hostname }}/genai_models.loc" && \
-    curl -H "Authorization: Bearer {{ llm_hub.token }}" "{{ llm_hub.endpoint }}/models" | \
-    jq -r --arg re "^({{ multimodals | join('|') }})" \
-      '.data[].id | if test($re) then [.,.,.,"multimodal","CERIT-SC","tag"] else [.,.,.,"text","CERIT-SC","tag"] end | @tsv' \
-      >> files/{{ inventory_hostname }}/genai_models.loc
-  become: false
-
 - name: Install the list of LLMs
   copy:
-    src: "files/{{ inventory_hostname }}/genai_models.loc"
+    src: "files/galaxy/genai_models.loc"
     dest: "{{ galaxy_tool_data_path }}/genai_models.loc"
 
 - name: Install specific local dependencies


### PR DESCRIPTION
Avoid querying the list of available models on ansible playbook run -- the list gets updated quite quickly and it confuses users. Instead, use a list of stable aliases described in docs: https://docs.cerit.io/en/docs/ai-as-a-service/chat-ai#model-aliases

Running the tool is not fully reproducible anymore as the underlying models can change. On the other hand, it would not be reproducible either because the obsolete models become unavailable anyway.